### PR TITLE
Use head block instead of the deprecated devel

### DIFF
--- a/Formula/jamf-pro.rb
+++ b/Formula/jamf-pro.rb
@@ -14,7 +14,7 @@ class JamfPro < Formula
   sha256 release["sha256"]
 
   # Used for the latest passing betas
-  devel do
+  head do
     url beta["url"], using: :nounzip
     version beta["version"]
     sha256 beta["sha256"]

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ To install beta channel releases, instead of the stable ones, add a `--head`
 flag after the brew commands:
 
 ```shell
-brew install jamf-pro --head
+brew install jamf-pro --HEAD
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -21,6 +21,15 @@ regular Homebrew package. For example:
 
 Check out the formulas in this repository to see what is available.
 
+## Beta Releases
+
+To install beta channel releases, instead of the stable ones, add a `--head`
+flag after the brew commands:
+
+```shell
+brew install jamf-pro --head
+```
+
 ## Contributing
 
 Feel free to contribute! If you created a tool that might be useful to others,


### PR DESCRIPTION
As of version 3.0.0 of Homebrew, [`devel` blocks are deprecated.](https://github.com/Homebrew/brew/commit/22857b56b9ff732c83f9bde3b58c3d579ac7f3b1) We should use `head` blocks instead.