### PR TITLE
Add rendr-sdk-groovy formula

### DIFF
--- a/Formula/rendr-sdk-groovy.rb
+++ b/Formula/rendr-sdk-groovy.rb
@@ -1,0 +1,19 @@
+class RendrSdkGroovy < Formula
+  desc "A rapid application development toolset - Groovy SDK"
+  homepage "https://github.com/jamf/rendr-sdk-groovy"
+
+  release_metadata = YAML.load(File.open(File.expand_path("../../metadata/rendr-sdk-groovy.yaml", __FILE__)).read)
+
+  url release_metadata["url"]
+  version release_metadata["version"]
+  sha256 release_metadata["sha256"]
+
+  def install
+    bin.install "bin/rendr-sdk-groovy"
+    prefix.install "lib"
+  end
+
+  test do
+    system "#{bin}/rendr-sdk-groovy", "--help"
+  end
+end

--- a/metadata/rendr-sdk-groovy.yaml
+++ b/metadata/rendr-sdk-groovy.yaml
@@ -1,0 +1,3 @@
+version: "v0.1.1"
+url: "https://github.com/jamf/rendr-sdk-groovy/releases/download/v0.1.1/rendr-sdk-groovy.zip"
+sha256: "555cdda688c54a39a41b2549efef3b8f9f4bd7c664d812848a1a7f85cf460804"


### PR DESCRIPTION
This formula is for the prototype version of the [Rendr SDK for Groovy](https://github.com/jamf/rendr-sdk-groovy). Adding it here even though it may get removed later, for ease of use and experimentation.